### PR TITLE
Use destroy so hooks are called

### DIFF
--- a/lib/app/routes/data_routes.rb
+++ b/lib/app/routes/data_routes.rb
@@ -121,7 +121,7 @@ Pakyow::App.routes :'console-data' do
           datum = type.model_object[params[:datum_id]]
 
           Pakyow::Console::ServiceHookRegistry.call(:before, :delete, type.name, datum, self)
-          datum.delete
+          datum.destroy
           Pakyow::Console::ServiceHookRegistry.call(:after, :delete, type.name, datum, self)
 
           notify("#{type.nice_name.downcase} deleted", :success)


### PR DESCRIPTION
I am not sure what all the implications of changing this might be.  This may introduce a problem with compatibility, in the event that console is being used with a different ORM than sequel.

The issue I ran into is that I needed to be able to destroy a model and have the hooks fire to delete related models at the same time.  In sequel calling delete will not fire the hooks, you have to call destroy.

![screenshot 2015-11-18 10 32 54](https://cloud.githubusercontent.com/assets/41271/11247011/c6cdf8c8-8ddf-11e5-8f83-8511f865ca40.png)

There is a facility in console that will allow me to call service hooks around this action, but it will only work via console.  That would have solved my immediate problem here, but I think it would be nice to have the ability to do both.  If I setup a background worker that reaped old records or something, and I wanted a before_destroy hook to fire that wrote logs about what was happening, I would want to be able to do that in my model and not have to go through console.

Let me know what you think, there is a good chance here that I might be missing something, or just might be completely wrong.
