### PR TITLE
Update `FileSystemAdapter` to accept extra args

### DIFF
--- a/lib/pakyow/console/file_store_adapters/file_system_adapter.rb
+++ b/lib/pakyow/console/file_store_adapters/file_system_adapter.rb
@@ -7,7 +7,7 @@ module Pakyow
         @store_path = Pakyow::Config.console.file_storage_path
       end
 
-      def store(tempfile, metadata)
+      def store(tempfile, metadata, **args)
         unless Dir.exists?(@store_path)
           Dir.mkdir(@store_path)
         end
@@ -22,24 +22,24 @@ module Pakyow
         reset
       end
 
-      def process(file, processed_data, w: nil, h: nil, m: nil)
+      def process(file, processed_data, w: nil, h: nil, m: nil, **args)
         path = processed_path(file[:id], w: w, h: h, m: m)
         File.open(processed_path(file[:id], w: w, h: h, m: m), 'wb+') do |f|
           f.write(processed_data)
         end
       end
 
-      def find(hash)
+      def find(hash, **args)
         files.find { |f| f[:id] == hash }
       end
 
-      def processed(hash, w: nil, h: nil, m: nil)
+      def processed(hash, w: nil, h: nil, m: nil, **args)
         path = processed_path(hash, w: w, h: h, m: m)
         return nil unless File.exists?(path)
         File.read(path)
       end
 
-      def data(hash)
+      def data(hash, **args)
         File.open(find(hash)[:path], 'rb')
       end
 


### PR DESCRIPTION
This PR updates the `FileSystemAdapter` to handle the extra args that `FileStore` now passes. This is the same set of changes that were made to the `DBFileAdapter` here: https://github.com/pakyow/console/commit/6098088dee071fc9f17270094ae30c1f6f4431f6#diff-dd29f0b77baab0dd1d731ef9931d466c.