### PR TITLE
reduce-icon-size

### DIFF
--- a/lib/pakyow/app/assets/console/styles/editors/_content.scss
+++ b/lib/pakyow/app/assets/console/styles/editors/_content.scss
@@ -108,6 +108,10 @@ $actions-width: 75px;
         @include rem(font-size, 20);
         color: $color-dgray;
 
+        @include mobile {
+          @include rem(font-size, 14);
+        }
+
         &:hover {
           color: $color-red;
         }
@@ -159,7 +163,7 @@ $actions-width: 75px;
 
       @include mobile {
         position: absolute;
-        top: -35px;
+        top: -28px;
         left: -5px;
 
       }
@@ -227,7 +231,7 @@ $actions-width: 75px;
   margin-right: 10px;
 
   @include mobile {
-    margin-top: -73px;
+    margin-top: -69px;
     margin-right: 0;
   }
 
@@ -235,6 +239,8 @@ $actions-width: 75px;
     margin-left: 15px;
     @include rem(font-size, 24);
     color: $color-lgray;
+
+    @include rem(font-size, 14);
   }
 }
 

--- a/lib/pakyow/app/assets/console/styles/editors/_content.scss
+++ b/lib/pakyow/app/assets/console/styles/editors/_content.scss
@@ -136,6 +136,10 @@ $actions-width: 75px;
   li {
     display: inline-block;
     margin-right: 10px;
+
+    @include mobile {
+      padding: 5px;
+    }
   }
 
   i {
@@ -159,10 +163,6 @@ $actions-width: 75px;
         left: -5px;
 
       }
-    }
-
-    @include mobile {
-      @include rem(font-size, 20);
     }
   }
 }


### PR DESCRIPTION
I made the icons their original size and added some padding so that the user can click on the correct one.
<img width="292" alt="screen shot 2017-03-01 at 10 35 14 am" src="https://cloud.githubusercontent.com/assets/8171067/23470119/310d2f7c-fe6b-11e6-931e-da931a7a60de.png">

fixes #133