### PR TITLE
Replace HTTP and relative URLs with HTTPS

### DIFF
--- a/lib/pakyow-console.rb
+++ b/lib/pakyow-console.rb
@@ -202,8 +202,8 @@ Pakyow::App.after :process do
       console_css = Pakyow::Assets.mixin_fingerprints(console_css)
     end
 
-    font_css = '<link href="//fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css">'
-    fa_css = '<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">'
+    font_css = '<link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css">'
+    fa_css = '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">'
 
     body = res.body[0]
     body.gsub!(CLOSING_HEAD_REGEX, console_css + font_css + fa_css + '</head>')

--- a/lib/views/_templates/default.slim
+++ b/lib/views/_templates/default.slim
@@ -10,8 +10,8 @@ html
     link href="/console/styles/common.css" rel="stylesheet" type="text/css"
     link href="/console/styles/console.css" rel="stylesheet" type="text/css"
 
-    link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
-    link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css"
+    link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
+    link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css"
 
     link rel="shortcut icon" href="/console/favicon.ico"
 

--- a/lib/views/_templates/minimal.slim
+++ b/lib/views/_templates/minimal.slim
@@ -10,8 +10,8 @@ html
     link href="/console/styles/common.css" rel="stylesheet" type="text/css"
     link href="/console/styles/minimal.css" rel="stylesheet" type="text/css"
 
-    link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
-    link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css"
+    link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
+    link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700" rel="stylesheet" type="text/css"
 
     link rel="shortcut icon" href="/console/favicon.ico"
 


### PR DESCRIPTION
When running a Console app on HTTPS you get [mixed content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content) errors because some of the external assets are requested via HTTP. This PR resolves that by [explicitly using HTTPS for assets that are available via HTTPS](https://www.paulirish.com/2010/the-protocol-relative-url/).