### PR TITLE
Fixes "unknown method router"

### DIFF
--- a/lib/pakyow/console/editors/relation_editor.rb
+++ b/lib/pakyow/console/editors/relation_editor.rb
@@ -3,13 +3,11 @@ Pakyow::Console.editor :relation do |_, related_datum, attribute, datum, datum_t
   editor = view.scope(:editor)[0]
   editor.scoped_as = :datum
 
-  view.component(:modal).with do
+  if attribute[:name] == datum_type.name
     # disallow self-referential relationships
-    if attribute[:name] == datum_type.name
-      remove
-    else
-      attrs.href = router.group(:data).path(:show, data_id: attribute[:name])
-    end
+    view.component(:modal).remove
+  else
+    view.component(:modal).attrs.href = router.group(:data).path(:show, data_id: attribute[:name])
   end
 
   related_class = attribute[:extras][:class]

--- a/lib/pakyow/console/editors/relation_editor.rb
+++ b/lib/pakyow/console/editors/relation_editor.rb
@@ -3,11 +3,13 @@ Pakyow::Console.editor :relation do |_, related_datum, attribute, datum, datum_t
   editor = view.scope(:editor)[0]
   editor.scoped_as = :datum
 
-  if attribute[:name] == datum_type.name
+  view.component(:modal).with do |view|
     # disallow self-referential relationships
-    view.component(:modal).remove
-  else
-    view.component(:modal).attrs.href = router.group(:data).path(:show, data_id: attribute[:name])
+    if attribute[:name] == datum_type.name
+      view.remove
+    else
+      view.attrs.href = router.group(:data).path(:show, data_id: attribute[:name])
+    end
   end
 
   related_class = attribute[:extras][:class]


### PR DESCRIPTION
I was getting [this error](https://gist.github.com/rjclardy/4a1bc713df330f4d2841cb63fe9265e6) after adding a `relation` attribute to my schema. It appears that global helpers like `router` aren’t available within view presenter blocks. So this PR changes it so that we’re no longer attempting to call `router` from inside a `with` block.