### PR TITLE
Make relation attributes listable

### DIFF
--- a/lib/pakyow/console.rb
+++ b/lib/pakyow/console.rb
@@ -51,6 +51,7 @@ require 'pakyow/console/editors/datetime_editor'
 
 require 'pakyow/console/formatters/percentage_formatter'
 require 'pakyow/console/formatters/datetime_formatter'
+require 'pakyow/console/formatters/relation_formatter'
 
 require 'pakyow/console/processors/boolean_processor'
 require 'pakyow/console/processors/file_processor'

--- a/lib/pakyow/console/formatters/relation_formatter.rb
+++ b/lib/pakyow/console/formatters/relation_formatter.rb
@@ -1,0 +1,5 @@
+Pakyow::Console::DatumFormatterRegistry.register :relation do |value|
+  if value
+    value.relation_name
+  end
+end

--- a/lib/pakyow/console/registries/data_type_registry.rb
+++ b/lib/pakyow/console/registries/data_type_registry.rb
@@ -1,5 +1,5 @@
 module Pakyow::Console::DataTypeRegistry
-  UNLISTABLE_TYPES = [:text, :file, :media, :html, :content, :relation]
+  UNLISTABLE_TYPES = [:text, :file, :media, :html, :content]
 
   def self.names
     datatypes.keys


### PR DESCRIPTION
This PR just makes it so that `relation` attributes can be listed on the data list pages. Console [already expects the related model to respond to `relation_name`](https://github.com/pakyow/console/blob/45be0a130e0b4ef9caa799f12e274b5ea96a198f/lib/pakyow/app/mutators/datum_mutator.rb#L14), so we're just reusing that here.