### PR TITLE
Fix pw_Collection's order function

### DIFF
--- a/lib/app/assets/console/scripts/ring/pakyow.js
+++ b/lib/app/assets/console/scripts/ring/pakyow.js
@@ -1015,7 +1015,7 @@ pw_Collection.prototype = {
   },
 
   order: function (orderedIds) {
-    orderedIds.forEach(function (id) {
+    orderedIds.forEach(function (id, i) {
       if (!id) {
         return;
       }


### PR DESCRIPTION
Fixes a bug in ring where it attempts to use an index variable `i` (line 1023) that hadn't actually been setup as an arg.